### PR TITLE
New option for Windows build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,8 @@ environment:
       Config: release
     - Build: 'Debug'
       Config: debug
+    - Build: 'Build with MT flag'
+      Config: MT_BUILD
 
 
 install:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ By default the project builds with ``devlib`` library and ``examples``
 
 + ``EXCLUDE_EXAMPLES_BUILD`` - skip ``examples`` build
 + ``ENABLE_HEADERS_COPY`` - ``devlib`` builds with public headers (will be located in ``include`` dir)
++ ``MT_BUILD`` - *Only for Windows 32-bit.* Build project with ``/MT`` flag. Default flag ``/MD``. see [references](https://msdn.microsoft.com/en-us/library/2kzt1wy3.aspx)
+
 
   Example:
 

--- a/devlib/devlib_deps.pri
+++ b/devlib/devlib_deps.pri
@@ -1,6 +1,11 @@
 
-win32:LIBS += \
+win32 {
+    MT_BUILD {
+        QMAKE_CXXFLAGS_RELEASE += /MT
+    }
+    LIBS += \
         -lsetupAPI \
+}
 
 linux:LIBS += \
         -ludev \


### PR DESCRIPTION
Add option for build library as /MT on Windows 32-bit