### PR TITLE
Improve device detecting on Windows

### DIFF
--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -306,7 +306,8 @@ namespace winutil {
         DevInfo devInfo;
         foreachDevices(TEXT("USB"),
             [&containerId, &devInfo] (DeviceProperties deviceProperties) -> void {
-                if (deviceProperties.containerId == containerId) {
+                if (deviceProperties.containerId == containerId
+                        && !deviceProperties.instanceId.contains("MI_")) {
                     devInfo.devId = extractDevPidVidInfo(deviceProperties.instanceId);
                     devInfo.usbPortPath = extractUsbPortPath(deviceProperties.locationPath);
                 }


### PR DESCRIPTION
device's location path may have interface information (USBMI):
PCIROOT(0)#PCI(1400)#USBROOT(0)#USB(2)#**USBMI(2)**
corresponding instance id is as follows:
"USB\\VID_3032&PID_0002&**MI_02**\\6&6E778E4&0&0002
usb port path: **1-2**

on some platforms USBMI tag appears as USB, so location path becomes incorrect:
PCIROOT(0)#PCI(1400)#USBROOT(0)#USB(2)**#USB(2)**
usb port path: **1-2.2**

Therefore it is reasonable to ignore instances with MI section. In this case usb port path would be detected correctly regardless of interfaces info