### PR TITLE
Draft: Windows: change detecting buses algorithm

### DIFF
--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -11,6 +11,7 @@
 #include <io.h>
 
 #include <memory>
+#include <stdlib.h>     /* malloc, free, rand */
 
 namespace winutil {
     Q_LOGGING_CATEGORY(winlog, "windows_native");
@@ -116,6 +117,203 @@ namespace winutil {
         return QString(instanceId)
                 .split("\\")[2]
                 .toLower();
+    }
+
+
+    #define SUCCESS 0
+    #define MAX_PATH_LENGTH 128
+
+
+    static char *sanitize_path(const char *path)
+    {
+        const char root_prefix[] = {'\\', '\\', '.', '\\'};
+        size_t j, size;
+        char *ret_path;
+        size_t add_root = 0;
+
+        if (path == NULL)
+            return NULL;
+
+        size = strlen(path) + 1;
+
+        // Microsoft indiscriminately uses '\\?\', '\\.\', '##?#" or "##.#" for root prefixes.
+        if (!((size > 3) && (((path[0] == '\\') && (path[1] == '\\') && (path[3] == '\\'))
+                || ((path[0] == '#') && (path[1] == '#') && (path[3] == '#'))))) {
+            add_root = sizeof(root_prefix);
+            size += add_root;
+        }
+
+        ret_path = (char *)malloc(size);
+        if (ret_path == NULL)
+            return NULL;
+
+        strcpy(&ret_path[add_root], path);
+
+        // Ensure consistency with root prefix
+        memcpy(ret_path, root_prefix, sizeof(root_prefix));
+
+        // Same goes for '\' and '#' after the root prefix. Ensure '#' is used
+        for (j = sizeof(root_prefix); j < size; j++) {
+            ret_path[j] = (char)toupper((int)ret_path[j]); // Fix case too
+            if (ret_path[j] == '\\')
+                ret_path[j] = '#';
+        }
+
+        return ret_path;
+    }
+
+    static int get_interface_details(
+            HDEVINFO dev_info, PSP_DEVINFO_DATA dev_info_data, LPCGUID guid, DWORD *_index, char **dev_interface_path)
+    {
+        SP_DEVICE_INTERFACE_DATA dev_interface_data;
+        PSP_DEVICE_INTERFACE_DETAIL_DATA_A dev_interface_details;
+        DWORD size;
+
+        dev_info_data->cbSize = sizeof(SP_DEVINFO_DATA);
+        dev_interface_data.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
+        for (;;) {
+            if (!SetupDiEnumDeviceInfo(dev_info, *_index, dev_info_data)) {
+                if (GetLastError() != ERROR_NO_MORE_ITEMS) {
+    //                usbi_err(ctx, "Could not obtain device info data for %s index %u: %s",
+    //                    guid_to_string(guid), *_index, windows_error_str(0));
+    //                return LIBUSB_ERROR_OTHER;
+                    qDebug() << "Could not obtain device info data for:" << _index;
+                    return -1;
+                }
+
+                // No more devices
+    //            return LIBUSB_SUCCESS;
+                return 0;
+            }
+
+            // Always advance the index for the next iteration
+            (*_index)++;
+
+            if (SetupDiEnumDeviceInterfaces(dev_info, dev_info_data, guid, 0, &dev_interface_data))
+                break;
+
+            if (GetLastError() != ERROR_NO_MORE_ITEMS) {
+    //            usbi_err(ctx, "Could not obtain interface data for %s devInst %X: %s",
+    //                guid_to_string(guid), dev_info_data->DevInst, windows_error_str(0));
+    //            return LIBUSB_ERROR_OTHER;
+                qDebug() << "Could not obtain interface data for" << _index << "devInst" << dev_info_data->DevInst;
+                return -1;
+            }
+
+            // Device does not have an interface matching this GUID, skip
+        }
+
+        // Read interface data (dummy + actual) to access the device path
+        if (!SetupDiGetDeviceInterfaceDetailA(dev_info, &dev_interface_data, NULL, 0, &size, NULL)) {
+            // The dummy call should fail with ERROR_INSUFFICIENT_BUFFER
+            if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    //            usbi_err(ctx, "could not access interface data (dummy) for %s devInst %X: %s",
+    //                guid_to_string(guid), dev_info_data->DevInst, windows_error_str(0));
+    //            return LIBUSB_ERROR_OTHER;
+                qDebug() << "could not access interface data (dummy) for" << _index << "devInst" << dev_info_data->DevInst;
+                return -1;
+            }
+        } else {
+    //        usbi_err(ctx, "program assertion failed - http://msdn.microsoft.com/en-us/library/ms792901.aspx is wrong");
+    //        return LIBUSB_ERROR_OTHER;
+            qDebug() << "program assertion failed - http://msdn.microsoft.com/en-us/library/ms792901.aspx is wrong";
+            return -1;
+        }
+
+        dev_interface_details = (PSP_DEVICE_INTERFACE_DETAIL_DATA_A)malloc(size);
+        if (dev_interface_details == NULL) {
+    //        usbi_err(ctx, "could not allocate interface data for %s devInst %X",
+    //            guid_to_string(guid), dev_info_data->DevInst);
+    //        return LIBUSB_ERROR_NO_MEM;
+            qDebug() << "could not allocate interface data for" << _index << "devInst" << dev_info_data->DevInst;
+            return -2;
+        }
+
+        dev_interface_details->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_A);
+        if (!SetupDiGetDeviceInterfaceDetailA(dev_info, &dev_interface_data,
+            dev_interface_details, size, NULL, NULL)) {
+    //        usbi_err(ctx, "could not access interface data (actual) for %s devInst %X: %s",
+    //            guid_to_string(guid), dev_info_data->DevInst, windows_error_str(0));
+            free(dev_interface_details);
+            qDebug() << "could not access interface data (actual) for" << _index << "devInst" << dev_info_data->DevInst;
+    //        return LIBUSB_ERROR_OTHER;
+            return -1;
+        }
+
+        *dev_interface_path = sanitize_path(dev_interface_details->DevicePath);
+        free(dev_interface_details);
+
+        if (*dev_interface_path == NULL) {
+    //        usbi_err(ctx, "could not allocate interface path for %s devInst %X",
+    //            guid_to_string(guid), dev_info_data->DevInst);
+    //        return LIBUSB_ERROR_NO_MEM;
+            qDebug() << "could not allocate interface path for" << _index << "devInst" << dev_info_data->DevInst;
+            return -2;
+        }
+
+    //    return LIBUSB_SUCCESS;
+        return 0;
+    }
+
+    static std::map<QString, int> initialize_root_busses(int &error_code)
+    {
+        auto rootHubsBussesMap = std::map<QString, int>{};
+
+        HDEVINFO *dev_info, dev_info_intf;
+        SP_DEVINFO_DATA dev_info_data;
+        DWORD _index = 0;
+    //    int r = LIBUSB_SUCCESS;
+        int r = 0;
+        // PASS 2 : (re)enumerate HUBS
+        dev_info_intf = SetupDiGetClassDevsA(nullptr, nullptr, nullptr, DIGCF_ALLCLASSES | DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        if (dev_info_intf == INVALID_HANDLE_VALUE) {
+    //        usbi_err(ctx, "failed to obtain device info list: %s", windows_error_str(0));
+    //        return LIBUSB_ERROR_OTHER;
+            qDebug() << "failed to obtain device info list";
+            error_code = -1;
+        }
+            dev_info = &dev_info_intf;
+            for (int busNumber = 1; ; busNumber++) {
+                // safe loop: free up any (unprotected) dynamic resource
+                // NB: this is always executed before breaking the loop
+                // Safe loop: end of loop conditions
+
+    //            if (r != LIBUSB_SUCCESS)
+                if (r != 0)
+
+                    break;
+
+                if (busNumber == UINT8_MAX) {
+    //                usbi_warn(ctx, "program assertion failed - found more than %u buses, skipping the rest.", UINT8_MAX);
+                    qDebug() << "program assertion failed - found more than" << UINT8_MAX << "buses, skipping the rest.";
+                    break;
+                }
+
+                // Except for GEN, all passes deal with device interfaces
+                char *dev_interface_path = nullptr;
+                r = get_interface_details(*dev_info, &dev_info_data, &GUID_DEVINTERFACE_USB_HOST_CONTROLLER, &_index, &dev_interface_path);
+    //            if ((r != LIBUSB_SUCCESS) || (dev_interface_path == NULL)) {
+                if ((r != 0) || (dev_interface_path == NULL)) {
+                    _index = 0;
+                    break;
+                }
+                free(dev_interface_path);
+
+                // Read the Device ID path
+                char instanceId[MAX_PATH_LENGTH];
+                if (!SetupDiGetDeviceInstanceIdA(*dev_info, &dev_info_data, instanceId, sizeof(instanceId), nullptr)) {
+    //                usbi_warn(ctx, "could not read the device instance ID for devInst %X, skipping",
+    //                      dev_info_data.DevInst);
+                    qDebug() << "could not read the device instance ID for devInst" << dev_info_data.DevInst << ", skipping";
+                    continue;
+                }
+                rootHubsBussesMap[QString(instanceId)] = busNumber;
+    //            printf("assigning HCD '%s' bus number %u\n", instanceId, busNumber);
+                qDebug() << "assigning HCD '" << instanceId << "' bus number" << busNumber;
+            }
+
+        SetupDiDestroyDeviceInfoList(dev_info_intf);
+        return rootHubsBussesMap;
     }
 
 

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -317,7 +317,7 @@ namespace winutil {
     }
 
 
-    static auto extractUsbPortPath(QString const& locationPath) {
+    static auto extractUSBPorts(QString const& locationPath) {
         QString ports = "";
         QRegExp usbPort("USB\\((\\d+)");
         int pos = 0;
@@ -325,11 +325,7 @@ namespace winutil {
             ports += QString(".") + usbPort.cap(1);
             pos += usbPort.matchedLength();
         }
-
-        QString hub = QString(locationPath).replace(QRegularExpression(".*USBROOT\\((\\d+).*"), "\\1");
-        hub = QString::number(hub.toInt() + 1);
-
-        return ports.replace(QRegularExpression("^\\."), hub + "-");
+        return ports;
     }
 
 
@@ -400,10 +396,12 @@ namespace winutil {
 
     static auto getUsbPortPath(DeviceProperties const& deviceProperties) {
         auto ports = extractUSBPorts(deviceProperties.locationPath);
+
         qDebug() << "PORTS:" << ports;
+
         QString busNumber = findBusNumber(deviceProperties.instanceId);
         return ports.replace(QRegularExpression("^\\."), busNumber + "-");
-     }
+    }
 
 
     static auto driveNumber(QString const& physicalDriveName) {
@@ -597,7 +595,7 @@ namespace winutil {
                 if (deviceProperties.containerId == containerId
                         && !deviceProperties.instanceId.contains("MI_")) {
                     devInfo.devId = extractDevPidVidInfo(deviceProperties.instanceId);
-                    devInfo.usbPortPath = extractUsbPortPath(deviceProperties.locationPath);
+                    devInfo.usbPortPath = getUsbPortPath(deviceProperties);
                     qDebug() << "ContainerId matched";
                     qDebug() << "device instanceId:" << deviceProperties.instanceId << ", port_path:" << devInfo.usbPortPath;
                 }


### PR DESCRIPTION
**Problem**
First: `libusb` enumerates busses by itself using rootHubs [link](https://github.com/libusb/libusb/blob/master/libusb/os/windows_winusb.c#L947)
Second: Currently, `devlib` uses `USBROOT(x)` value that returns via _SeupAPI_ (`PySerial` does the similar [link](https://github.com/pyserial/pyserial/blob/master/serial/tools/list_ports_windows.py#L235))

If computer has more than one RootHubs, these two algorithm returns different busses for the same device.

**Solution**
Use the same algorithm for `libusb` and `devlib`

**Changes**
The detection and enumeration algorithm for busses in Windows has been changed to be the same as in `libusb`