### PR TITLE
Windows: create device list once before each iteration over devices

### DIFF
--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -269,6 +269,7 @@ namespace winutil {
             handler(devInfo);
         }
 
+        SetupDiDestroyDeviceInfoList(hDevInfo);
         return true;
     }
 

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -448,8 +448,8 @@ std::vector<std::tuple<int, int, QString, QString>>
             devicesList.emplace_back(
                 devId.vid,
                 devId.pid,
-                deviceFilePath,
-                usbPortPath
+                std::move(deviceFilePath),
+                std::move(usbPortPath)
             );
         }
     );


### PR DESCRIPTION
**GoodDay:** 
* [don't recreate USB device list for every USBSTOR device](https://www.goodday.work/t/gKeAU6),

## Motivation
We created a new USB devices list for each Storage devices, `N^2` is a terrible waste of time. Plus, we don't free the devices list after iteration. :(
++, we iterate over device Interfaces even after `deviceDiskPath` has been found. This should also be fixed.

## Solution
Create the USB devices list only once and just use its elements with Storage devices. 
Stop iteration over Interfaces after `deviceDiskPath` is found

## Changes

- Free devices list when `ForEachDevice` iteration is done
- Create USB devices list only once
- Stop `ForEachInterface` iteration after `deviceDiskPath` is found