### PR TITLE
Windows: change enumerating buses algorithm

### DIFF
--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -542,6 +542,14 @@ std::vector<std::tuple<int, int, QString, QString>>
         }
     );
 
+    qDebug(winutil::winlog()) << "Devices list:";
+    for (auto& device : devicesList) {
+        qDebug(winutil::winlog()) << "vid:" << std::get<0>(device)
+                << ", pid:" << std::get<1>(device)
+                << ", filePath:" << std::get<2>(device)
+                << ", portPath:" << std:: get<3>(device);
+    }
+
     return devicesList;
 }
 

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -13,9 +13,13 @@
 #include <memory>
 
 #include <QMap>
+#include <QSet>
 
 namespace winutil {
     Q_LOGGING_CATEGORY(winlog, "windows_native");
+
+    constexpr auto UNABLE_TO_GET_DEV_PARENT = -1;
+    constexpr auto UNABLE_TO_GET_DEV_ID = -2;
 
     constexpr auto win32IOBlockDivider(void) {
         return 512;
@@ -167,6 +171,54 @@ namespace winutil {
         hub = QString::number(hub.toInt() + 1);
 
         return ports.replace(QRegularExpression("^\\."), hub + "-");
+    }
+
+
+    static auto findBusNumber(DEVINST const& handle, QMap<QString, int> & cachedDeviceBuses) {
+        static auto rootHubsBuses = QMap<QString, int>{};
+        if (rootHubsBuses.isEmpty()) {
+            qDebug(winlog()) << "Enumerating buses...";
+            rootHubsBuses = enumerateRootBuses();
+        }
+        qDebug(winlog()) << "Buses" << rootHubsBuses;
+
+        auto currentDevInst = handle;
+        DEVINST parentDevInst;
+        WCHAR instanceID [MAX_DEVICE_ID_LEN];
+
+        auto traversedDevices = QSet<QString>{};
+        CM_Get_Device_ID(currentDevInst, instanceID , MAX_PATH, 0);
+        traversedDevices.insert(QString::fromWCharArray(instanceID));
+
+        int bus;
+        for(;;) {
+            if (CM_Get_Parent(&parentDevInst, currentDevInst, 0) != CR_SUCCESS) {
+                bus = UNABLE_TO_GET_DEV_PARENT;
+                break;
+            }
+            if (CM_Get_Device_ID(parentDevInst, instanceID , MAX_PATH, 0) != CR_SUCCESS) {
+                bus = UNABLE_TO_GET_DEV_ID;
+                break;
+            }
+
+            auto parentInstanceId = QString::fromWCharArray(instanceID);
+            qDebug(winlog()) << "parentInstanceId" << parentInstanceId;
+            if (rootHubsBuses.contains(parentInstanceId)) {
+                bus = rootHubsBuses[parentInstanceId];
+                break;
+            }
+            if (cachedDeviceBuses.contains(parentInstanceId)) {
+                bus = cachedDeviceBuses[parentInstanceId];
+                break;
+            }
+            traversedDevices.insert(parentInstanceId);
+            currentDevInst = parentDevInst;
+        }
+
+        for (auto & devInstanceId : traversedDevices) {
+            cachedDeviceBuses[devInstanceId] = bus;
+        }
+        return QString::number(bus);
     }
 
 

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -101,6 +101,7 @@ namespace winutil {
         QString instanceId;
         QString containerId;
         QString locationPath;
+        DEVINST handle;
     };
 
     using DeviceInterfaceHandler = std::function<bool(PSP_DEVICE_INTERFACE_DETAIL_DATA)>;
@@ -336,6 +337,7 @@ namespace winutil {
             if (status != CR_SUCCESS)
                 continue;
 
+            devInfo.handle = DeviceInfoData.DevInst;
             devInfo.instanceId = QString::fromWCharArray(szDeviceInstanceID);
 
             if (SetupDiGetDevicePropertyW (hDevInfo, &DeviceInfoData, &DEVPKEY_Device_BusReportedDeviceDesc,

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -159,7 +159,7 @@ namespace winutil {
     }
 
 
-    static auto extractUsbPortPath(QString const& locationPath) {
+    static auto extractUSBPorts(QString const& locationPath) {
         QString ports = "";
         QRegExp usbPort("USB\\((\\d+)");
         int pos = 0;
@@ -167,11 +167,7 @@ namespace winutil {
             ports += QString(".") + usbPort.cap(1);
             pos += usbPort.matchedLength();
         }
-
-        QString hub = QString(locationPath).replace(QRegularExpression(".*USBROOT\\((\\d+).*"), "\\1");
-        hub = QString::number(hub.toInt() + 1);
-
-        return ports.replace(QRegularExpression("^\\."), hub + "-");
+        return ports;
     }
 
 
@@ -220,6 +216,16 @@ namespace winutil {
             cachedDeviceBuses[devInstanceId] = bus;
         }
         return QString::number(bus);
+    }
+
+
+    static auto getUsbPortPath(const DEVINST & handle,
+                               const QString & locationPath,
+                               QMap<QString, int> & cachedDeviceBuses) {
+        auto ports = extractUSBPorts(locationPath);
+
+        QString busNumber = findBusNumber(handle, cachedDeviceBuses);
+        return ports.replace(QRegularExpression("^\\."), busNumber + "-");
     }
 
 
@@ -510,9 +516,10 @@ std::vector<std::tuple<int, int, QString, QString>>
 {
     auto devicesList = std::vector<std::tuple<int, int, QString, QString>>();
     auto usbDevicesByContainerIdsMap = winutil::getMapOfUsbDevicesByContainerIds();
+    auto cachedDevicesBuses = QMap<QString, int>{};
 
     winutil::foreachDevices(TEXT("USBSTOR"),
-        [&devicesList, &usbDevicesByContainerIdsMap]
+        [&devicesList, &usbDevicesByContainerIdsMap, &cachedDevicesBuses]
                             (winutil::DeviceProperties deviceProperties) -> void {
             QString deviceInstanceId = deviceProperties.instanceId;
             auto driveNum = winutil::driveNumber(
@@ -530,7 +537,7 @@ std::vector<std::tuple<int, int, QString, QString>>
             }
 
             auto devId = winutil::extractDevPidVidInfo(usbDevProperties.instanceId);
-            auto usbPortPath = winutil::extractUsbPortPath(usbDevProperties.locationPath);
+            auto usbPortPath = winutil::getUsbPortPath(usbDevProperties.handle, usbDevProperties.locationPath, cachedDevicesBuses);
             auto deviceFilePath = winutil::nameFromDriveNumber(driveNum);
 
             devicesList.emplace_back(


### PR DESCRIPTION
> ⚠️~Depends on the following PRs, which have to be merged first: #9~ (merged)

**GoodDay:** 
* [Change the device bus enumerating algorithm in the "Devlib"](https://www.goodday.work/t/YKVcT9)

## Motivation
Another library, that works with physical devices is `libsub`. It has a different bus enumeration algorithm. It enumerates Roots Hubs and finds, which Hub is the parent for the device. To be able to use `Devlib` and `libusb` in one project, we need to change the Bus enumeration algorithm on Windows

## Solution
Use the same algorithm, that `libusb` uses. Find all Root Hubs and enumerate them. 

## Changes

- Added function, that gets all Root Hubs (`initializeRootBuses`)
- Added function, that finds device BusNumber using Root Hubs (`findBusNumber`)
- `DEVINST` field was added to `DeviceProperties` structure to find device parent. ( `CM_Get_Parent` call use it)
- `locationPath` is currently used only to get device ports. Bus Number is obtained using the `findBusNumber` function.
