### PR TITLE
Add MacOs ports path support

### DIFF
--- a/devlib/native/macosx_native.cpp
+++ b/devlib/native/macosx_native.cpp
@@ -298,8 +298,12 @@ auto devlib::native::requestUsbDeviceList(void)
         ::CFNumberGetValue(vidRef, kCFNumberSInt32Type, &vid);
         ::CFNumberGetValue(pidRef, kCFNumberSInt32Type, &pid);
 
-        //usbPortPath is not yet supported. Therefore LocationPortPath is None
-        devlist.push_back(std::make_tuple(vid, pid, QString("/dev/%1").arg(bsdName), QString("None")));
+        auto usbPortPath = macxutil::getUsbPortPath(usbDeviceRef);
+        if (usbPortPath.isEmpty()) {
+            qCCritical(macxutil::macxlog()) << "Unable to get USB port path";
+        }
+
+        devlist.push_back(std::make_tuple(vid, pid, QString("/dev/%1").arg(bsdName), usbPortPath));
     }
 
     return devlist;


### PR DESCRIPTION
**GoodDay:** [Devlib: MacOs: add UsbPortsPath support](https://www.goodday.work/t/X8q34Z)

## Motivation
`devlib` still unable to show device ports path on MacOs

## Solution
Get `usbPortsPath` from the device's `locationID` property. `LocationID` has the following form: `0x14324000`, where the first 2 digits are the bus number, the others are USB ports.


## Changes
- `getUsbPortPath` function was added.
- `None` ports path was replaced by a valid one.