### PR TITLE
Allow users without admin privileges open storage device on macOS

### DIFF
--- a/devlib/StorageDeviceFile.h
+++ b/devlib/StorageDeviceFile.h
@@ -19,6 +19,11 @@ public:
         return open_core(mode);
     }
 
+    bool authOpen(OpenMode mode) {
+        Q_ASSERT(!isOpen());
+        return open_core(mode, true);
+    }
+
     void close(void) override final { close_core(); }
     auto fileName() const
         -> QString override final { return fileName_core(); }
@@ -54,7 +59,7 @@ protected:
     }
 
 private:
-    virtual bool open_core(OpenMode mode) = 0;
+    virtual bool open_core(OpenMode mode, bool withAuthorization = false) = 0;
     virtual void close_core(void) = 0;
     virtual void sync_core() = 0;
 

--- a/devlib/devlib_deps.pri
+++ b/devlib/devlib_deps.pri
@@ -12,4 +12,6 @@ macx {
     LIBS += \
         -framework IOKit \
         -framework CoreFoundation \
+        -framework Security \
+
 }

--- a/devlib/impl/MountpointImpl.h
+++ b/devlib/impl/MountpointImpl.h
@@ -35,7 +35,7 @@ private:
 
     virtual auto umount_core(void)
         -> std::unique_ptr<devlib::IMountpointLock> override
-    { return _locksFactory(native::umount(_fsPath)); }
+    { return _locksFactory(native::umountPartition(_fsPath)); }
 
     QString _fsPath;
     impl::MountpointLockFactory_t _locksFactory;

--- a/devlib/impl/StorageDeviceFileImpl.cpp
+++ b/devlib/impl/StorageDeviceFileImpl.cpp
@@ -31,7 +31,7 @@ devlib::impl::StorageDeviceFileImpl::
 { }
 
 
-bool devlib::impl::StorageDeviceFileImpl::open_core(OpenMode mode)
+bool devlib::impl::StorageDeviceFileImpl::open_core(OpenMode mode, bool withAuthorization)
 {
     Q_UNUSED(mode);
     // first: unmount disk
@@ -39,7 +39,11 @@ bool devlib::impl::StorageDeviceFileImpl::open_core(OpenMode mode)
          return false;
     }
     // second: open file handle
-    _fileHandle = native::io::open(_deviceFilename.toStdString().data());
+    if (withAuthorization) {
+        _fileHandle = native::io::authOpen(_deviceFilename.toStdString().data());
+    } else {
+        _fileHandle = native::io::open(_deviceFilename.toStdString().data());
+    }
 
     QFile::setOpenMode(mode);
 

--- a/devlib/impl/StorageDeviceFileImpl.cpp
+++ b/devlib/impl/StorageDeviceFileImpl.cpp
@@ -14,13 +14,10 @@ bool devlib::impl::StorageDeviceFileImpl::open_core(OpenMode mode)
     Q_UNUSED(mode);
     // first: unmount all mounpoints
     auto mntpts = _deviceInfo->mountpoints();
-    _mntptsLocks.clear();
 
     for (auto const& mntpt : mntpts) {
         auto mntptLock = mntpt->umount();
-        if (mntptLock->locked()){
-            _mntptsLocks.push_back(std::move(mntptLock));
-        } else {
+        if (!mntptLock->locked()){
             return false;
         }
     }
@@ -38,7 +35,6 @@ void devlib::impl::StorageDeviceFileImpl::close_core(void)
 {
     QFile::setOpenMode(QIODevice::NotOpen);
     _fileHandle.reset();
-    _mntptsLocks.clear();
 }
 
 

--- a/devlib/impl/StorageDeviceFileImpl.h
+++ b/devlib/impl/StorageDeviceFileImpl.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~StorageDeviceFileImpl(void) { close_core(); }
 private:
-    virtual bool open_core(OpenMode mode) override;
+    virtual bool open_core(OpenMode mode, bool withAuthorization = false) override;
     virtual void close_core(void) override;
 
     virtual auto readData_core(char* data, qint64 len)

--- a/devlib/impl/StorageDeviceFileImpl.h
+++ b/devlib/impl/StorageDeviceFileImpl.h
@@ -23,22 +23,19 @@ public:
 
     virtual ~StorageDeviceFileImpl(void) { close_core(); }
 private:
-    virtual bool open_core(OpenMode mode, bool withAuthorization = false) override;
-    virtual void close_core(void) override;
+    bool open_core(OpenMode mode, bool withAuthorization = false) override;
+    void close_core(void) override;
 
-    virtual auto readData_core(char* data, qint64 len)
-        -> qint64 override;
+    auto readData_core(char* data, qint64 len) -> qint64 override;
 
-    virtual auto writeData_core(char const* data, qint64 len)
-        -> qint64 override;
+    auto writeData_core(char const* data, qint64 len) -> qint64 override;
 
-    virtual auto fileName_core(void) const
+    auto fileName_core(void) const
         -> QString override { return _deviceFilename; }
 
-    virtual auto seek_core(qint64)
-        -> bool override;
+    auto seek_core(qint64) -> bool override;
 
-    virtual void sync_core(void) override;
+    void sync_core(void) override;
 
     QString _deviceFilename;
     std::shared_ptr<devlib::IStorageDeviceInfo> _deviceInfo;

--- a/devlib/impl/StorageDeviceFileImpl.h
+++ b/devlib/impl/StorageDeviceFileImpl.h
@@ -42,7 +42,6 @@ private:
 
     QString _deviceFilename;
     std::shared_ptr<devlib::IStorageDeviceInfo> _deviceInfo;
-    std::vector<std::unique_ptr<IMountpointLock>> _mntptsLocks;
 
     std::unique_ptr<
         native::io::FileHandle

--- a/devlib/native/linux_native.cpp
+++ b/devlib/native/linux_native.cpp
@@ -287,6 +287,15 @@ auto devlib::native::io::open(char const* filename)
 }
 
 
+// Temporarily unsupported
+auto devlib::native::io::authOpen(char const* filename)
+    -> std::unique_ptr<FileHandle>
+{
+    Q_UNUSED(filename);
+    return nullptr;
+}
+
+
 auto devlib::native::io::seek(FileHandle* handle, qint64 pos)
    -> bool
 {

--- a/devlib/native/linux_native.cpp
+++ b/devlib/native/linux_native.cpp
@@ -118,6 +118,13 @@ auto devlib::native::umountPartition(QString const& mntpt)
 }
 
 
+// Temporarily unsupported
+bool devlib::native::umountDisk(QString const & devicePath)
+{
+    Q_UNUSED(devicePath);
+    return false;
+}
+
 
 bool devlib::native::mount(QString const& dev, QString const& path)
 {

--- a/devlib/native/linux_native.cpp
+++ b/devlib/native/linux_native.cpp
@@ -102,7 +102,7 @@ namespace linutil {
     }
 }
 
-auto devlib::native::umount(QString const& mntpt)
+auto devlib::native::umountPartition(QString const& mntpt)
     -> std::unique_ptr<LockHandle>
 {
     if (::umount2(mntpt.toStdString().data(), 0) != 0) {

--- a/devlib/native/macos_utils/auth_open.cpp
+++ b/devlib/native/macos_utils/auth_open.cpp
@@ -1,0 +1,166 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020 Raspberry Pi (Trading) Limited
+ */
+
+ /**
+ * authOpenStorageDevice implementation based on authOpen function from RPI-Imager
+ * https://github.com/raspberrypi/rpi-imager/blob/qml/mac/macfile.cpp
+ * Anohin Igor <igor.anohin@emlid.com>, 2021
+ */
+
+#include "macos_utils.h"
+
+#include <sys/socket.h>
+
+#include <security/Authorization.h>
+
+
+namespace {
+    using authorization_uptr = std::unique_ptr<std::remove_pointer<AuthorizationRef>::type,
+                                               std::function<void(AuthorizationRef)>>;
+
+
+    auto createFileAuthorization(const QByteArray & filename) -> authorization_uptr {
+        QByteArray right = "sys.openfile.readwrite." + filename;
+        AuthorizationItem item = {right, 0, nullptr, 0};
+        AuthorizationFlags flags = kAuthorizationFlagInteractionAllowed | kAuthorizationFlagExtendRights
+                                   | kAuthorizationFlagPreAuthorize;
+        AuthorizationRights rights = {1, &item};
+
+        auto authsDestructor = [](AuthorizationRef authRef) {
+            if (authRef != nullptr) {
+                AuthorizationFree(authRef, 0);
+            }
+        };
+
+        AuthorizationRef authRef = nullptr;
+        if (AuthorizationCreate(&rights, nullptr, flags, &authRef) != 0) {
+            return nullptr;
+        }
+
+        return authorization_uptr{authRef, authsDestructor};
+    }
+
+
+    void handleChildProcess(const char * filename, int * pipe, int * stdinpipe)
+    {
+        // Close unused pipes
+        ::close(pipe[0]);
+        ::close(stdinpipe[1]);
+
+        // Assign pipes with std in/out
+        ::dup2(pipe[1], STDOUT_FILENO);
+        ::dup2(stdinpipe[0], STDIN_FILENO);
+
+        const char * cmd = "/usr/libexec/authopen";
+        QByteArray mode = QByteArray::number(O_RDWR);
+        ::execl(cmd, cmd, "-stdoutpipe", "-extauth", "-o", mode.data(), filename, nullptr);
+
+        // Exit with error code -1 in case of execl error
+        ::exit(-1);
+    }
+
+
+    auto receiveFdFromChildProcess(const int & fromChildToParentPipe) -> int
+    {
+        const size_t bufSize = CMSG_SPACE(sizeof(int));
+        char buf[bufSize];
+        struct iovec io_vec[1];
+        io_vec[0].iov_base = buf;
+        io_vec[0].iov_len = bufSize;
+        const size_t cmsgSize = CMSG_SPACE(sizeof(int));
+        char cmsg[cmsgSize];
+
+        struct msghdr msg = {0};
+        msg.msg_iov = io_vec;
+        msg.msg_iovlen = 1;
+        msg.msg_control = cmsg;
+        msg.msg_controllen = cmsgSize;
+
+        ssize_t size;
+        do {
+            size = recvmsg(fromChildToParentPipe, &msg, 0);
+        } while (size == -1 && errno == EINTR);
+
+        if (size > 0) {
+            struct cmsghdr * chdr = CMSG_FIRSTHDR(&msg);
+            if (chdr && chdr->cmsg_type == SCM_RIGHTS) {
+                qCDebug(macos_utils::macxlog()) << "SCMRIGHTS";
+                return *((int *)(CMSG_DATA(chdr)));
+            } else {
+                qCDebug(macos_utils::macxlog()) << "NOT SCMRIGHTS";
+                return -1;
+            }
+        }
+        return -2;
+    }
+
+
+    auto waitForChildProcessToFinish(const int & processId) -> int
+    {
+        pid_t wpid;
+        int status;
+
+        do {
+            wpid = ::waitpid(processId, &status, 0);
+        } while (wpid == -1 && errno == EINTR);
+
+        if (wpid == -1) {
+            qCDebug(macos_utils::macxlog()) << "waitpid() failed executing authopen";
+            return -2;
+        }
+        if (WEXITSTATUS(status)) {
+            qCDebug(macos_utils::macxlog()) << "authopen returned failure code" << WEXITSTATUS(status);
+            return -3;
+        }
+
+        return 0;
+    }
+
+}
+
+
+namespace macos_utils {
+    auto authOpenStorageDevice(const QByteArray & filename) -> int
+    {
+        auto authorizationUPtr = createFileAuthorization(filename);
+        if (!authorizationUPtr) {
+            return -1;
+        }
+
+        AuthorizationExternalForm externalForm;
+        if (AuthorizationMakeExternalForm(authorizationUPtr.get(), &externalForm) != 0) {
+            return -1;
+        }
+
+        int fd = -1;
+
+        int pipe[2];
+        int stdinpipe[2];
+        ::socketpair(AF_UNIX, SOCK_STREAM, 0, pipe);
+        ::pipe(stdinpipe);
+        auto pid = ::fork();
+        if (pid == 0) {
+            handleChildProcess(filename.data(), pipe, stdinpipe);
+        } else {
+            // Close unused pipes
+            ::close(pipe[1]);
+            ::close(stdinpipe[0]);
+
+            // Send AuthorizationExternalForm structure, because "extauth" was used in authopen
+            ::write(stdinpipe[1], externalForm.bytes, sizeof(externalForm.bytes));
+            ::close(stdinpipe[1]);
+
+            fd = receiveFdFromChildProcess(pipe[0]);
+
+            auto exitCode = waitForChildProcessToFinish(pid);
+            if (exitCode != 0) {
+                return exitCode;
+            }
+
+            qCDebug(macxlog()) << "fd received:" << fd;
+        }
+        return fd;
+    }
+}

--- a/devlib/native/macos_utils/macos_utils.cpp
+++ b/devlib/native/macos_utils/macos_utils.cpp
@@ -1,0 +1,140 @@
+#include "macos_utils.h"
+
+namespace  {
+
+    auto convertHexQStringToDecQString(const QString & hexNumber) -> QString
+    {
+        return QString::number(hexNumber.toInt(nullptr, 16));
+    }
+
+}
+
+namespace macos_utils {
+    Q_LOGGING_CATEGORY(macxlog, "macx_native");
+
+    auto makeHandle(int fd) -> std::unique_ptr<MacxFileHandle> {
+        return std::make_unique<MacxFileHandle>(fd);
+    }
+
+
+    auto asMacxFileHandle(devlib::native::io::FileHandle* handle) -> MacxFileHandle* {
+        return dynamic_cast<MacxFileHandle*>(handle);
+    }
+
+
+    auto makeLock() -> std::unique_ptr<MacxLock> {
+        return std::make_unique<MacxLock>();
+    }
+
+
+    bool extractValueByKey(
+        QDomElement const& domElement, QString const& keyName,
+        std::function<void(QString const&)> onSuccess
+    ) {
+        if (domElement.tagName() == "key" && domElement.text() == keyName) {
+            auto valueElement = domElement.nextSiblingElement("string");
+            onSuccess(valueElement.text());
+            return true;
+        }
+
+        return false;
+    }
+
+
+    bool isDiskName(QString const& diskName) {
+        return diskName.startsWith("/dev/disk");
+    }
+
+
+    auto convertToRawDiskName(QString const& diskName)  -> QString {
+        return QString(diskName).replace("/dev/", "/dev/r");
+    }
+
+
+    auto extractArrayWithPartitionsOfDevice(
+            QDomElement const& docElement, QString const& deviceName
+    ) -> QDomNode
+    {
+        auto arrays = docElement.elementsByTagName("array");
+
+        for (int i = 0; i < arrays.count(); i++) {
+            auto array = arrays.at(i);
+            auto parent = array.parentNode();
+
+            if (!parent.isNull() && parent.isElement()) {
+                auto dict = parent.toElement();
+                if (dict.tagName() != "dict") { continue; }
+
+                auto dictChilds = dict.childNodes();
+
+                for (auto j = 0; j < dictChilds.count(); j++) {
+                    auto dictChild = dictChilds.at(j).toElement();
+
+                    if (dictChild.tagName() == "key" && dictChild.text() == "DeviceIdentifier") {
+                        auto devnameElem = dictChild.nextSiblingElement("string");
+                        if (devnameElem.text() == deviceName) {
+                           return array;
+                        }
+                    }
+                }
+            }
+        }
+
+        return {};
+    }
+
+
+    auto MYCFStringCopyUTF8String(CFStringRef aString)
+        -> char*
+    {
+        if (aString == NULL) {
+            return NULL;
+        }
+
+        CFIndex length = CFStringGetLength(aString);
+        CFIndex maxSize =
+        CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+        char *buffer = (char *)malloc(maxSize);
+        if (CFStringGetCString(aString, buffer, maxSize,
+                             kCFStringEncodingUTF8)) {
+            return buffer;
+        }
+        free(buffer); // If we failed
+        return NULL;
+    }
+
+
+    auto extractBusNumberFromLocationId(const QString & locationID) -> QString
+    {
+        return convertHexQStringToDecQString(locationID.left(2));
+    }
+
+
+    auto extractUsbPortsFromLocationId(const QString & locationID) -> QStringList
+    {
+        auto usbPortsInHex = QString{locationID}.remove(0,2) // remove leading bus number
+                                                .remove("0") // remove trailing zeros
+                                                .split("", QString::SkipEmptyParts);
+        auto usbPorts = QStringList{};
+        std::transform(usbPortsInHex.cbegin(),
+                       usbPortsInHex.cend(),
+                       std::back_inserter(usbPorts),
+                       convertHexQStringToDecQString);
+        return usbPorts;
+    }
+
+
+    auto getUsbPortPath(io_service_t usbDeviceRef) -> QString
+    {
+        io_name_t locationID;
+        auto result = ::IORegistryEntryGetLocationInPlane(usbDeviceRef, kIOServicePlane, locationID);
+        if (result != KERN_SUCCESS) {
+            return {};
+        }
+        auto busNumber = extractBusNumberFromLocationId(locationID);
+        auto usbPorts = extractUsbPortsFromLocationId(locationID);
+        return busNumber + "-" + usbPorts.join(".");
+    }
+
+}
+

--- a/devlib/native/macos_utils/macos_utils.h
+++ b/devlib/native/macos_utils/macos_utils.h
@@ -67,6 +67,8 @@ namespace macos_utils {
 
     auto unmountDiskWithRunLoop(const char * device) -> UnmountResult;
 
+    auto authOpenStorageDevice(const QByteArray & filename) -> int;
+
 }
 
 

--- a/devlib/native/macos_utils/macos_utils.h
+++ b/devlib/native/macos_utils/macos_utils.h
@@ -1,0 +1,60 @@
+#ifndef MACX_UTIL_H
+#define MACX_UTIL_H
+
+#include "../native.h"
+
+#include <unistd.h>
+
+#import <IOKit/usb/IOUSBLib.h>
+#import <IOKit/IOBSD.h>
+
+#include <QtXml>
+
+
+namespace macos_utils {
+    Q_DECLARE_LOGGING_CATEGORY(macxlog);
+
+
+    struct MacxFileHandle : public devlib::native::io::FileHandle {
+        int fd;
+        constexpr MacxFileHandle(int in_fd) : fd(in_fd) {}
+        virtual ~MacxFileHandle(void) { ::fsync(fd); ::close(fd); }
+    };
+
+
+    auto makeHandle(int fd) -> std::unique_ptr<MacxFileHandle>;
+
+    auto asMacxFileHandle(devlib::native::io::FileHandle* handle) -> MacxFileHandle*;
+
+    struct MacxLock : public devlib::native::LockHandle {
+        virtual ~MacxLock() = default;
+    };
+
+
+    auto makeLock() -> std::unique_ptr<MacxLock>;
+
+    bool extractValueByKey(
+        QDomElement const& domElement, QString const& keyName,
+        std::function<void(QString const&)> onSuccess
+    );
+
+    bool isDiskName(QString const& diskName);
+
+    auto convertToRawDiskName(QString const& diskName) -> QString;
+
+    auto extractArrayWithPartitionsOfDevice(
+            QDomElement const& docElement, QString const& deviceName
+    ) -> QDomNode;
+
+    auto MYCFStringCopyUTF8String(CFStringRef aString) -> char*;
+
+    auto extractBusNumberFromLocationId(const QString & locationID) -> QString;
+
+    auto extractUsbPortsFromLocationId(const QString & locationID) -> QStringList;
+
+    auto getUsbPortPath(io_service_t usbDeviceRef) -> QString;
+
+}
+
+
+#endif // MACX_UTIL_H

--- a/devlib/native/macos_utils/macos_utils.h
+++ b/devlib/native/macos_utils/macos_utils.h
@@ -54,6 +54,19 @@ namespace macos_utils {
 
     auto getUsbPortPath(io_service_t usbDeviceRef) -> QString;
 
+    enum class UnmountResult
+    {
+        Undefined,
+        Success,
+        InvalidDriveError,
+        AccessDeniedError,
+        RunloopStallError,
+        GeneralError
+    };
+
+
+    auto unmountDiskWithRunLoop(const char * device) -> UnmountResult;
+
 }
 
 

--- a/devlib/native/macos_utils/unmount_disk.cpp
+++ b/devlib/native/macos_utils/unmount_disk.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /**
+ * Unmount Disk implementation based on unmount_disk function from RPI-Imager
+ * https://github.com/raspberrypi/rpi-imager/blob/qml/dependencies/mountutils/src/darwin/functions.cpp
+ * Anohin Igor <igor.anohin@emlid.com>, 2021
+ */
+
+#include "macos_utils.h"
+
+#include <type_traits>
+
+#include <DiskArbitration/DiskArbitration.h>
+
+
+namespace {
+    struct UnmountRunLoopContext
+    {
+        macos_utils::UnmountResult result = macos_utils::UnmountResult::Undefined;
+    };
+
+
+    macos_utils::UnmountResult convertDissenterToUnmountResult(DADissenterRef dissenter)
+    {
+        DAReturn status = DADissenterGetStatus(dissenter);
+        if (status == kDAReturnBadArgument || status == kDAReturnNotFound) {
+            qCDebug(macos_utils::macxlog()) << "Invalid drive";
+            return macos_utils::UnmountResult::InvalidDriveError;
+        } else if (status == kDAReturnNotPermitted || status == kDAReturnNotPrivileged) {
+            qCDebug(macos_utils::macxlog()) << "Access denied";
+            return macos_utils::UnmountResult::AccessDeniedError;
+        } else {
+            qCDebug(macos_utils::macxlog()) << "Unknown dissenter status";
+            return macos_utils::UnmountResult::GeneralError;
+        }
+    }
+
+
+    void unmountCallback(DADiskRef disk, DADissenterRef dissenter, void * ctx)
+    {
+        Q_UNUSED(disk)
+
+        qCDebug(macos_utils::macxlog()) << "Unmount callback";
+        UnmountRunLoopContext * context = reinterpret_cast<UnmountRunLoopContext *>(ctx);
+        if (dissenter) {
+            qCDebug(macos_utils::macxlog()) << "Unmount dissenter";
+            context->result = convertDissenterToUnmountResult(dissenter);
+        } else {
+            qCDebug(macos_utils::macxlog()) << "Unmount success";
+            context->result = macos_utils::UnmountResult::Success;
+        }
+        CFRunLoopStop(CFRunLoopGetCurrent());
+    }
+
+
+    bool waitForRunningLoop(const UnmountRunLoopContext & context)
+    {
+        // Wait for the run loop: Run with a timeout of 500ms (0.5s),
+        // and don't terminate after only handling one resource.
+        // NOTE: As the unmount callback gets called *before* the runloop can
+        // be started here when there's no device to be unmounted or
+        // the device has already been unmounted, the loop would
+        // hang indefinitely until stopped manually otherwise.
+        // Here we repeatedly run the loop for a given time, and stop
+        // it at some point if it hasn't gotten anywhere, or if there's
+        // nothing to be unmounted, or a dissent has been caught before the run.
+        // This way we don't have to manage state across callbacks.
+        for (auto attempt = 0; attempt < 10; attempt++) {
+            // See https://developer.apple.com/reference/corefoundation/1541988-cfrunloopruninmode
+            SInt32 status = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.5, false);
+            // Stop starting the runloop once it's been manually stopped
+            if ((status == kCFRunLoopRunStopped) || (status == kCFRunLoopRunFinished)) {
+                return true;
+            }
+            // Bail out if DADiskUnmount caught a dissent and
+            // thus returned before the runloop even started
+            if (context.result != macos_utils::UnmountResult::Undefined) {
+                qCDebug(macos_utils::macxlog()) << "Runloop dry";
+                return true;
+            }
+            // Bail out if the runloop is timing out, but not getting anywhere
+        }
+
+        return false;
+    }
+
+}
+
+
+namespace macos_utils {
+
+    UnmountResult unmountDiskWithRunLoop(const char * device)
+    {
+        using session_uptr = std::unique_ptr<std::remove_pointer<DASessionRef>::type,
+                                                   std::function<void(DASessionRef)>>;
+        using disk_uptr = std::unique_ptr<std::remove_pointer<DADiskRef>::type,
+                                                   std::function<void(DADiskRef)>>;
+
+        // Create a session object
+        qCDebug(macxlog()) << "Creating DA session";
+        session_uptr session(DASessionCreate(kCFAllocatorDefault),
+                             [](DASessionRef session) {
+                                 if (session != nullptr) {
+                                     CFRelease(session);
+                                 }
+                             });
+
+        if (!session) {
+            qCDebug(macxlog()) << "Session couldn't be created";
+            return UnmountResult::GeneralError;
+        }
+
+        // Get a disk object from the disk path
+        qCDebug(macxlog()) << "Getting disk object";
+
+        disk_uptr disk(DADiskCreateFromBSDName(kCFAllocatorDefault, session.get(), device),
+                       [](DADiskRef disk) {
+                           if (disk != nullptr) {
+                               CFRelease(disk);
+                           }
+                       });
+        if (!disk) {
+            qCDebug(macxlog()) << "Disk couldn't be created";
+            return UnmountResult::GeneralError;
+        }
+
+        UnmountRunLoopContext context;
+        // Unmount, and then eject from the unmount callback
+        qCDebug(macxlog()) << "Unmounting";
+        DADiskUnmount(
+            disk.get(), kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce, unmountCallback, &context);
+
+        // Schedule a disk arbitration session
+        qCDebug(macxlog()) << "Schedule session on run loop";
+        DASessionScheduleWithRunLoop(session.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+
+        qCDebug(macxlog()) << "Waiting run loop";
+        if (!waitForRunningLoop(context)) {
+            qCDebug(macxlog()) << "Runloop stall";
+            context.result = UnmountResult::RunloopStallError;
+        }
+
+        // Clean up the session
+        qCDebug(macxlog()) << "Releasing session & disk object";
+        DASessionUnscheduleFromRunLoop(session.get(), CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        return context.result;
+    }
+
+}
+

--- a/devlib/native/macosx_native.cpp
+++ b/devlib/native/macosx_native.cpp
@@ -163,6 +163,13 @@ auto devlib::native::umountPartition(QString const& mntpt)
 }
 
 
+bool devlib::native::umountDisk(QString const & devicePath)
+{
+    auto unmountResult = macos_utils::unmountDiskWithRunLoop(devicePath.toStdString().data());
+    return unmountResult == macos_utils::UnmountResult::Success;
+}
+
+
 bool devlib::native::mount(const QString &dev, const QString &path)
 {
     QProcess mount;

--- a/devlib/native/macosx_native.cpp
+++ b/devlib/native/macosx_native.cpp
@@ -292,6 +292,27 @@ auto devlib::native::io::open(char const* filename)
 }
 
 
+auto devlib::native::io::authOpen(char const* filename)
+    -> std::unique_ptr<FileHandle>
+{
+    if (!macos_utils::isDiskName(filename)) {
+         qCWarning(macos_utils::macxlog()) << filename << " is not diskname";
+         return {};
+     }
+
+     auto rawDiskName = macos_utils::convertToRawDiskName(filename);
+
+     auto fd = macos_utils::authOpenStorageDevice(rawDiskName.toUtf8());
+
+     if (fd < 0) {
+         qCWarning(macos_utils::macxlog()) << "Unable to open file with authentication";
+         return {};
+     }
+
+     return macos_utils::makeHandle(fd);
+}
+
+
 bool devlib::native::io::seek(FileHandle* handle, qint64 pos)
 {
     Q_ASSERT(handle);

--- a/devlib/native/macosx_native.cpp
+++ b/devlib/native/macosx_native.cpp
@@ -310,7 +310,7 @@ auto devlib::native::requestUsbDeviceList(void)
 }
 
 
-auto devlib::native::umount(QString const& mntpt)
+auto devlib::native::umountPartition(QString const& mntpt)
     -> std::unique_ptr<LockHandle>
 {
     auto mntptName = mntpt.toStdString();

--- a/devlib/native/native.h
+++ b/devlib/native/native.h
@@ -17,6 +17,8 @@ namespace devlib {
         auto umountPartition(QString const& mntpt)
             -> std::unique_ptr<LockHandle>;
 
+        bool umountDisk(QString const & devicePath);
+
         bool mount(QString const& dev, QString const& path);
 
         auto mntptsList(void) -> std::vector<QString>;

--- a/devlib/native/native.h
+++ b/devlib/native/native.h
@@ -43,6 +43,9 @@ namespace devlib {
             auto open(char const* filename)
                 -> std::unique_ptr<FileHandle>;
 
+            auto authOpen(char const * filename)
+                -> std::unique_ptr<FileHandle>;
+
             bool seek(FileHandle*, qint64 pos);
 
             void sync(FileHandle* handle);

--- a/devlib/native/native.h
+++ b/devlib/native/native.h
@@ -14,7 +14,7 @@ namespace devlib {
             virtual ~LockHandle() = default;
         };
 
-        auto umount(QString const& mntpt)
+        auto umountPartition(QString const& mntpt)
             -> std::unique_ptr<LockHandle>;
 
         bool mount(QString const& dev, QString const& path);

--- a/devlib/native/native.pri
+++ b/devlib/native/native.pri
@@ -19,4 +19,5 @@ macx {
         $$PWD/macosx_native.cpp \
         $$PWD/macos_utils/macos_utils.cpp \
         $$PWD/macos_utils/unmount_disk.cpp \
+        $$PWD/macos_utils/auth_open.cpp \
 }

--- a/devlib/native/native.pri
+++ b/devlib/native/native.pri
@@ -12,6 +12,10 @@ linux {
 }
 
 macx {
+    HEADERS += \
+        $$PWD/macos_utils/macos_utils.h \
+
     SOURCES  += \
         $$PWD/macosx_native.cpp \
+        $$PWD/macos_utils/macos_utils.cpp \
 }

--- a/devlib/native/native.pri
+++ b/devlib/native/native.pri
@@ -18,4 +18,5 @@ macx {
     SOURCES  += \
         $$PWD/macosx_native.cpp \
         $$PWD/macos_utils/macos_utils.cpp \
+        $$PWD/macos_utils/unmount_disk.cpp \
 }

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -457,6 +457,14 @@ auto devlib::native::umountPartition(QString const& mntpt)
 }
 
 
+// Temporarily unsupported
+bool devlib::native::umountDisk(QString const & devicePath)
+{
+    Q_UNUSED(devicePath);
+    return false;
+}
+
+
 // Temporary unsupported
 bool devlib::native::mount(QString const& dev, QString const& path)
 {

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -669,6 +669,15 @@ auto devlib::native::io::open(char const* filename)
 }
 
 
+// Temporarily unsupported
+auto devlib::native::io::authOpen(char const* filename)
+    -> std::unique_ptr<FileHandle>
+{
+    Q_UNUSED(filename);
+    return nullptr;
+}
+
+
 bool devlib::native::io::seek(FileHandle* handle, qint64 pos)
 {
     auto winHandle = dynamic_cast<winutil::WinHandle*>(handle)->handle;

--- a/devlib/native/win_native.cpp
+++ b/devlib/native/win_native.cpp
@@ -415,7 +415,7 @@ namespace winutil {
 }
 
 
-auto devlib::native::umount(QString const& mntpt)
+auto devlib::native::umountPartition(QString const& mntpt)
     -> std::unique_ptr<LockHandle>
 {
     auto createMode = FILE_SHARE_READ | FILE_SHARE_WRITE;

--- a/examples/devlib_cli/main.cpp
+++ b/examples/devlib_cli/main.cpp
@@ -1,9 +1,9 @@
-#include <QCoreApplication>
 #include "devlib.h"
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication a(argc, argv);
+    Q_UNUSED(argc)
+    Q_UNUSED(argv)
 
     auto service = devlib::StorageDeviceService::instance();
     Q_ASSERT(service.get());
@@ -35,6 +35,4 @@ int main(int argc, char *argv[])
             qInfo() << "";
         }
     }
-
-    return a.exec();
 }


### PR DESCRIPTION
**GoodDay:** [Flasher for Mac Can't Connect to M2](https://www.goodday.work/t/ehulLE)

## Motivation
Non-admin users are unable to reflash devices, because `sudo --askpass` doesn't work and they can't open storage devices for writing.
In general, there are 2 problems. Users without admin privileges:
1) Unable to unmount disk mount points.
2) Unable to open storage devices

## Solution
For the "1)" problem solution is [DADiskUnmount](https://developer.apple.com/documentation/diskarbitration/1492758-dadiskunmount?language=objc) function, which allows to unmout the whole disk. It's enough to be able to write.
An example was picked from https://github.com/raspberrypi/rpi-imager/blob/8a44c6b3ca99b87896451d7fe48342955675bad4/dependencies/mountutils/src/darwin/functions.cpp#L171


For the "2)" problem solution is `/usr/libexec/authopen` util, which allows entering admin password and get a special fd for storage file.
An example was picked from https://github.com/raspberrypi/rpi-imager/blob/8a44c6b3ca99b87896451d7fe48342955675bad4/mac/macfile.cpp#L25

## How to test
1) Get a storage device, that has mount points. For example, I picked ReachRS2.
2) Put the device into storage mode
3) Patch `devlib_cli` example. Here is the patch: 
[changed_devlib_cli.txt](https://github.com/emlid/devlib/files/5844038/changed_devlib_cli.txt)

> To apply the patch use the following command: `$ git apply changed_devlib_cli.txt`
4) Run `devlib_cli` and check the result. You should see something like:
```shell
$  ./devlib_cli
...output...
-> Use device on "20-3.4" port
...output...
-> macx_native: Unmounting
-> macx_native: Schedule session on run loop
-> macx_native: Waiting run loop
-> macx_native: Unmount callback
-> macx_native: Unmount success
...output...
-> Opening: false
...output...
-> Auth Opening: true
``` 

## Changes
- `devlib/native`:
    - `umount` -> `umountParition`
    - `umountDisk` function has been added and implemented on macOS
    - `authOpen` function has been added and implemented on macOS
- `StorageDeviceFile`:
    - `authOpen` function has been added
    - `StorageDeviceFileImpl` tries unmount the whole disk instead of mountpoints
    - unused 'mntptLock' object member has been removed from `StorageDeviceFileImpl`
- `devlib_cli`:
    - `QCoreApplication` events loop has been removed