### PR TITLE
Fix storage device opening during flashing on Windows

### DIFF
--- a/devlib/impl/StorageDeviceFileImpl.h
+++ b/devlib/impl/StorageDeviceFileImpl.h
@@ -39,6 +39,7 @@ private:
 
     QString _deviceFilename;
     std::shared_ptr<devlib::IStorageDeviceInfo> _deviceInfo;
+    std::vector<std::unique_ptr<IMountpointLock>> _mntptsLocks;
 
     std::unique_ptr<
         native::io::FileHandle


### PR DESCRIPTION
**GoodDay:** [Unable to reflash device on Reach Flasher on Windows](https://www.goodday.work/t/TsXwPw)

## Steps to reproduce
1. Build Reach Flasher on `dev` branch on Windows
2. Try to reflash a device

## Expected behavior
Device is successfully flashed

## Actual behavior
The flashing fails at the very beginning, in the logs there is an error message `Flashing Failed: write error`, and in some cases during storage device opening, there is a warning message `Can not lock volume: "\\\\.\\D:"`
The issue is reproduced at least for RS2 and M2

## Description
The issue occurred after commit [`5a10d2c`](https://github.com/emlid/devlib/commit/5a10d2ca178a4aed1b767aca02df1a0562b8cf36)

## Proposed solution
- add `_mntptsLocks` object member back to `StorageDeviceFileImpl`

