### PR TITLE
Use IOUSBHostDevice for macOS USB request

### DIFF
--- a/devlib/native/macosx_native.cpp
+++ b/devlib/native/macosx_native.cpp
@@ -96,7 +96,7 @@ auto devlib::native::requestUsbDeviceList(void)
         return {};
     }
 
-    auto matchDictionary = IOServiceMatching(kIOUSBDeviceClassName);
+    auto matchDictionary = IOServiceMatching("IOUSBHostDevice");
     if (!matchDictionary) {
         qCCritical(macos_utils::macxlog()) << "can not create matching dictionary";
         return {};


### PR DESCRIPTION
**ClickUp**: [Could we detect bad port/hub during flashing?](https://app.clickup.com/t/4727576/EMB-2675)

## Steps to reproduce

1. Build Reach Flash Tool for macOS
2. Run it for any new macOS version (Monterey)
3. Try to reflash a device

## Expected behavior
The device is successfully flashed

## Actual behavior
The flashing fails at the very beginning with the message: "Flasher failed result message: Can't find storage device". The issue is reproduced for RS2 and M2 at least. 

## Description
The kIOUSBDeviceClassName was changed in El Capitan but for some reason, it wasn't deprecated until macOS Monterey where it's not working at all. Thus, the matching dictionary is created but it couldn't find any storage devices at all.

## Proposed solution
Since El Capitan is a 10.11 version and we have 10.14 as minimal supported, I just replaced the kIOUSBDeviceClassName with IOUSBHostDevice.
